### PR TITLE
Fix return error if reject is not a function

### DIFF
--- a/lib/components/client-manager/index.js
+++ b/lib/components/client-manager/index.js
@@ -132,31 +132,31 @@ exports = module.exports = function(fs, config, StreamManager, log, rateLimiter)
                 return this.onSFTP(client, accept, reject);
             });
             session.on('exec', (accept, reject) => {
-                return reject();
+                return typeof reject === 'function' ? reject() : reject;
             });
             session.on('pty', (accept, reject) => {
-                return reject();
+                return typeof reject === 'function' ? reject() : reject;
             });
             session.on('window-change', (accept, reject) => {
-                return reject();
+                return typeof reject === 'function' ? reject() : reject;
             });
             session.on('x11', (accept, reject) => {
-                return reject();
+                return typeof reject === 'function' ? reject() : reject;
             });
             session.on('env', (accept, reject) => {
-                return reject();
+                return typeof reject === 'function' ? reject() : reject;
             });
             session.on('signal', (accept, reject) => {
-                return reject();
+                return typeof reject === 'function' ? reject() : reject;
             });
             session.on('auth-agent', (accept, reject) => {
-                return reject();
+                return typeof reject === 'function' ? reject() : reject;
             });
             session.on('shell', (accept, reject) => {
-                return reject();
+                return typeof reject === 'function' ? reject() : reject;
             });
             session.on('subsystem', (accept, reject) => {
-                return reject();
+                return typeof reject === 'function' ? reject() : reject;
             });
         }
 


### PR DESCRIPTION
I got a TypeError: reject is not a function. It can be fixed by type checking reject and only calling it as a function if it is in fact a function.