### PR TITLE
Emit file data on file upload

### DIFF
--- a/lib/components/stream-manager/index.js
+++ b/lib/components/stream-manager/index.js
@@ -355,6 +355,8 @@ exports = module.exports = function(fs, config, log) {
                 return this.sendStatus(reqID, STATUS_CODE.FAILURE);
             }
 
+            this.server.emit('data', data);
+
             return adapter.write(offset, data)
                 .then(() => {
                     return this.sendStatus(reqID, STATUS_CODE.OK);


### PR DESCRIPTION
By emitting file data it's content can be used in additional tasks.
In my case, the sftp server will accept csv files that will be parsed and written to database along with storing the raw files on disk.